### PR TITLE
Add prominent resume download and personal branding to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,22 @@
-# 🚀 Career Agent
+# Ian Alloway - Resume & Career Tools
+
+**Data Scientist | AI Specialist | Blockchain Analyst**
+
+[![Download Resume](https://img.shields.io/badge/Download-Resume%20(PDF)-blue?style=for-the-badge&logo=adobe-acrobat-reader)](https://github.com/ianalloway/Resume/raw/main/Ian%20Alloway_CV.pdf)
+[![Portfolio](https://img.shields.io/badge/Portfolio-ianalloway.xyz-00D100?style=for-the-badge&logo=google-chrome&logoColor=white)](https://ianalloway.xyz)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-Connect-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/ianit)
+
+---
+
+## About Me
+
+I'm pursuing a Masters in Artificial Intelligence at the University of South Florida while running Alloway LLC, where I specialize in AI-driven cybersecurity solutions and blockchain analytics. I transform complex datasets into actionable insights, bridging cutting-edge AI research with practical business applications.
+
+**Key Skills:** Python, Machine Learning, TensorFlow, Deep Learning, SQL, Data Analytics, Blockchain, Power BI, Tableau
+
+---
+
+## Career Agent Tool
 
 An AI-powered career assistance tool that helps you optimize your resume, prepare for interviews, get career advice, and accelerate your professional growth. Built with modular architecture supporting multiple AI providers (OpenAI and Anthropic).
 


### PR DESCRIPTION
## Summary
Updates the README to prominently feature Ian's resume with a download button and adds personal branding. The existing Career Agent tool documentation is preserved under a new subsection.

Changes:
- Added professional header with name and title
- Added shields.io badge buttons for Resume download, Portfolio, and LinkedIn
- Added "About Me" section with bio and key skills
- Renamed the main section to "Career Agent Tool" to distinguish from the personal branding

## Review & Testing Checklist for Human
- [ ] **Verify resume download link works** - Click the "Download Resume" badge and confirm the PDF downloads correctly. The filename contains a space (`Ian Alloway_CV.pdf`) which is URL-encoded as `%20`
- [ ] **Test external links** - Verify portfolio (ianalloway.xyz) and LinkedIn links resolve correctly
- [ ] **Check badge rendering** - After merging, confirm the shields.io badges display properly on the repo page

### Test Plan
1. Merge the PR
2. Visit https://github.com/ianalloway/Resume
3. Click the "Download Resume" badge - should download the PDF
4. Click Portfolio and LinkedIn badges - should open correct pages
5. Verify all badges render with correct colors and icons

### Notes
- Link to Devin run: https://app.devin.ai/sessions/79b2218c13784145ac50150fb81d91c1
- Requested by: Ian Alloway