### PR TITLE
fix: Update Drone AI URL to ai-drone-auto-vehicle

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ I'm pursuing a Masters in Artificial Intelligence at the University of South Flo
 - **[ClawHub Skills](https://clawhub.ai)** - Published AI agent skills: sports-odds, nft-tracker, data-viz, screenshot-annotator
 - **[Money Maker Bot](https://github.com/ianalloway/Money-maker-bot)** - Financial intelligence assistant built on OpenClaw
 - **[Sports Betting ML](https://huggingface.co/spaces/ianalloway/sports-betting-ml)** - NBA prediction model with XGBoost and Kelly Criterion value betting
-- **[Drone AI](https://github.com/ianalloway/drone-ai)** - Autonomous vehicle intelligence platform with computer vision, path planning, and MAVLink integration
+- **[Drone AI](https://github.com/ianalloway/ai-drone-auto-vehicle)** - Autonomous vehicle intelligence platform with computer vision, path planning, and MAVLink integration
 
 ## Education
 


### PR DESCRIPTION
## Summary
Updates the Drone AI project link in the Open Source Contributions section to point to the correct repository URL. The repo was created as `ai-drone-auto-vehicle` instead of `drone-ai`.

## Review & Testing Checklist for Human
- [ ] Verify the link https://github.com/ianalloway/ai-drone-auto-vehicle resolves correctly

**Test plan:** Click the Drone AI link after merging to confirm it works.

### Notes
- Requested by: Ian Alloway
- Link to Devin run: https://app.devin.ai/sessions/79b2218c13784145ac50150fb81d91c1