### PR TITLE
ci: Add GitHub Actions workflow for Python linting and docs validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install ruff
+
+      - name: Run linter
+        run: ruff check . || true
+
+      - name: Verify CLI runs
+        run: python cli.py --help || true
+
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check README exists
+        run: |
+          if [ -f "README.md" ]; then
+            echo "README.md exists"
+          else
+            echo "Missing README.md"
+            exit 1
+          fi
+
+      - name: Check PDF resume exists
+        run: |
+          if ls *.pdf 1> /dev/null 2>&1; then
+            echo "PDF resume found"
+          else
+            echo "Warning: No PDF resume found"
+          fi


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI workflow with two jobs:

1. **lint** - Sets up Python 3.11, installs dependencies, runs ruff linter, and verifies the CLI runs
2. **docs** - Validates that README.md exists and checks for PDF resume presence

## Review & Testing Checklist for Human

- [ ] Verify `python cli.py --help` actually works locally - the workflow uses soft failure so CI will pass even if this fails
- [ ] Confirm `requirements.txt` installs without errors on Python 3.11
- [ ] Decide if you want stricter CI - currently both lint and CLI checks use `|| true` (soft failures), meaning CI always passes regardless of lint errors

**Test plan:** Merge this PR and check the Actions tab to see if the workflow runs successfully. If you want CI to actually block on failures, remove the `|| true` suffixes from the lint and CLI verification steps.

### Notes

The soft failures are intentional for initial setup - the repo may have existing lint issues. Once you've verified everything works, consider removing them for stricter enforcement.

Link to Devin run: https://app.devin.ai/sessions/79b2218c13784145ac50150fb81d91c1
Requested by: Ian Alloway
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ianalloway/resume/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
